### PR TITLE
#2 [UI] 행사일정 페이지 구현

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,11 +1,13 @@
 import { BrowserRouter as Router, Route, Routes } from "react-router-dom"
 import ColorTest from "./components/common/ColorTest"
+import Events from "./pages/Events"
 
 function App() {
   return (
     <Router>
       <Routes>
         <Route path="/color-test" element={<ColorTest />} />
+        <Route path="/events" element={<Events />} />
       </Routes>
     </Router>
   )

--- a/src/components/events/EventCard.jsx
+++ b/src/components/events/EventCard.jsx
@@ -1,0 +1,44 @@
+export default function EventCard({ title, date, isDisabled = false }) {
+  // 날짜에 숫자가 포함되어 있는지 확인 (예: '3월 10일' -> true, '추후 공지' -> false)
+  const hasDateNumber = /\d/.test(date);
+
+  // 보더를 보여줄 조건: 비활성화 상태가 아니고(AND) 날짜 형식(숫자 포함)일 때
+  const showBorder = !isDisabled && hasDateNumber;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {/* 제목 부분 */}
+      <div
+        className={`
+          px-6 py-4 text-center flex items-center justify-center h-20 rounded-lg transition-all duration-200
+          ${
+            isDisabled
+              ? 'bg-gray-04 text-black opacity-60'
+              : 'bg-bright-orange-02 text-bg-dark hover:shadow-lg'
+          }
+        `}
+      >
+        <div className="body-18-bold">{title}</div>
+      </div>
+
+      {/* 날짜 부분 */}
+      <div
+        className={`
+          px-6 py-4 text-center flex items-center justify-center h-20 rounded-lg transition-all duration-200
+          ${
+            isDisabled
+              ? 'text-gray-04 opacity-60'
+              : 'text-gray-01 hover:shadow-lg'
+          }
+          ${
+            showBorder ? 'border-2 border-gray-01' : ''
+          }
+        `}
+      >
+        <div className={hasDateNumber ? "body-18-bold" : "body-18-regular text-gray-04 opacity-60"}>
+          {date}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/events/EventSeason.jsx
+++ b/src/components/events/EventSeason.jsx
@@ -1,0 +1,59 @@
+import EventCard from './EventCard';
+
+export default function EventSeason({ season, monthsData, seasonColor, description }) {
+  const filteredMonths = monthsData.filter(monthData => monthData.events.length > 0);
+
+  return (
+    <div className="flex gap-6 mb-16">
+      
+      {/* 1. 왼쪽: 계절 제목 */}
+      <div className="flex-shrink-0 w-24 text-right pt-1">
+        <h2 
+          className="title-24-semibold break-keep"
+          style={{ color: seasonColor }}
+        >
+          {season}
+        </h2>
+      </div>
+
+      {/* 2. 중앙: 세로 줄 */}
+      <div className="flex flex-col items-center relative">
+        <div 
+          className="w-1 flex-1 -mt-2"
+          style={{ backgroundColor: seasonColor }}
+        ></div>
+        <div 
+          className="w-4 h-4 rounded-full flex-shrink-0 z-10"
+          style={{ backgroundColor: seasonColor }}
+        ></div>
+      </div>
+
+      {/* 3. 오른쪽: 컨텐츠 영역 */}
+      <div className="flex-1 pb-8"> 
+        {description && (
+          <div className="mb-8">
+            {description}
+          </div>
+        )}
+
+        <div className="space-y-12">
+          {filteredMonths.map((monthData) => (
+            <div key={monthData.month}>
+              <h3 className="title-28-semibold text-white mb-4">{monthData.month}</h3>
+              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+                {monthData.events.map((event, index) => (
+                  <EventCard
+                    key={index}
+                    title={event.title}
+                    date={event.date}
+                    isDisabled={event.isDisabled}
+                  />
+                ))}
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -4,12 +4,39 @@
   --font-family-sans: "Pretendard", -apple-system, BlinkMacSystemFont,
     "Segoe UI", sans-serif;
 
+  /* Typography - Title */
+  --font-size-title-64: 64px;
+  --font-size-title-32: 32px;
+  --font-size-title-28: 28px;
+  --font-size-title-24: 24px;
+  --font-size-title-20: 20px;
+
+  /* Typography - Body */
+  --font-size-body-18: 18px;
+  --font-size-body-16: 16px;
+  --font-size-body-14: 14px;
+
+  /* Typography - Detail */
+  --font-size-detail-12: 12px;
+  --font-size-detail-10: 10px;
+
+  /* Font Weights */
+  --font-weight-regular: 400;
+  --font-weight-semibold: 600;
+  --font-weight-bold: 700;
+
+  /* Line Heights */
+  --line-height-120: 120%;
+  --line-height-130: 130%;
+  --line-height-150: 150%;
+
   /* Colors - Orange Palette */
   --color-orange-gradient: #BA4E23;
   --color-orange-01: #6C2D14;
   --color-orange-02: #804229;
   --color-orange-03: #DC8563;
   --color-orange-04: #BA4E23;
+  --color-orange-hover: #531E08;
   --color-bright-orange-01: #FFE4D3;
   --color-bright-orange-02: #F3EAE5;
   --color-bright-orange-01-hover: #ECCEBB;
@@ -21,16 +48,91 @@
   --color-gray-01: #EDEDED;
   --color-gray-02: #D9D9D9;
   --color-gray-03: #B0B0B0;
-  --color-gray-05: #8F8F8F;
-  --color-gray-07: #515154;
+  --color-gray-04: #8F8F8F;
+  --color-gray-05: #6C6C6C;
+  --color-gray-06: #515154;
+  --color-gray-07: #2D2D2D;
 
   /* Colors - Background */
   --color-bg-dark: #080300;
   --color-bg-secondary: #1C1C1C;
+  --color-bg-transparency: #080300/70;
 }
 
 @layer base {
   :root {
     color-scheme: dark;
+  }
+
+  /* Title Styles */
+  .title-120-bold {
+    @apply text-[120px] font-bold leading-[120%];
+  }
+
+  .title-64-bold {
+    @apply text-[64px] font-bold leading-[120%];
+  }
+
+  .title-32-semibold {
+    @apply text-[32px] font-semibold leading-[130%];
+  }
+
+  .title-28-semibold {
+    @apply text-[28px] font-semibold leading-[130%];
+  }
+
+  .title-24-semibold {
+    @apply text-[24px] font-semibold leading-[130%];
+  }
+
+  .title-20-semibold {
+    @apply text-[20px] font-semibold leading-[130%];
+  }
+
+  /* Body Styles */
+  .body-18-regular {
+    @apply text-[18px] font-regular leading-[150%];
+  }
+
+  .body-18-semibold {
+    @apply text-[18px] font-semibold leading-[150%];
+  }
+
+  .body-18-bold {
+    @apply text-[18px] font-bold leading-[150%];
+  }
+
+  .body-16-regular {
+    @apply text-[16px] font-regular leading-[150%];
+  }
+
+  .body-16-semibold {
+    @apply text-[16px] font-semibold leading-[150%];
+  }
+
+  .body-14-regular {
+    @apply text-[14px] font-regular leading-[150%];
+  }
+
+  .body-14-semibold {
+    @apply text-[14px] font-semibold leading-[150%];
+  }
+
+  /* Detail Styles */
+  .detail-12-regular {
+    @apply text-[12px] font-regular leading-[150%];
+  }
+
+  .detail-12-semibold {
+    @apply text-[12px] font-semibold leading-[150%];
+  }
+
+  .detail-10-regular {
+    @apply text-[10px] font-regular leading-[150%];
+  }
+
+  /* Gradient */
+  .bg-orange-gradient {
+    background: linear-gradient(135deg, #BA4E23 0%, #080300 100%);
   }
 }

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -1,0 +1,119 @@
+import EventSeason from '../components/events/EventSeason';
+
+export default function Events() {
+  // 1학기
+  const eventsSemester1 = [
+    {
+      month: '3월',
+      events: [
+        { title: 'OT', date: '3월 10일', isDisabled: false },
+        { title: 'MT', date: '3월 13일 ~ 14일', isDisabled: false },
+        { title: '세션 진행', date: '3월 19일', isDisabled: false },
+        { title: '세션 진행', date: '3월 26일', isDisabled: false },
+      ],
+    },
+    {
+      month: '4월',
+      events: [
+        { title: '세션 진행', date: '4월 2일', isDisabled: false },
+        { title: '세션 진행', date: '4월 9일', isDisabled: false },
+        { title: '휴회', date: '중간고사 기간', isDisabled: true },
+        { title: '세션 진행', date: '4월 30일', isDisabled: false },
+      ],
+    },
+    {
+      month: '5월',
+      events: [
+        { title: '세션 진행', date: '5월 7일', isDisabled: false },
+        { title: '세션 진행', date: '5월 14일', isDisabled: false },
+        { title: '기획/디자인 발표', date: '5월 21일', isDisabled: false },
+        { title: '해커톤 팀빌딩', date: '5월 28일', isDisabled: false },
+      ],
+    },
+    {
+      month: '6월',
+      events: [
+        { title: '휴회', date: '기말고사 기간 + 해커톤 준비', isDisabled: true },
+      ],
+    },
+  ];
+
+  // 방학
+  const eventsSummer = [
+    {
+      month: '7월',
+      events: [
+        { title: '애거돈', date: '추후 공지', isDisabled: false },
+        { title: '방학 세션 진행', date: '추후 공지', isDisabled: false },
+      ],
+    },
+    {
+      month: '8월',
+      events: [
+        { title: '해커톤', date: '추후 공지', isDisabled: false },
+      ],
+    },
+  ];
+
+  // 2학기
+  const eventsSemester2 = [
+    {
+      month: '9월',
+      events: [],
+    },
+    {
+      month: '10월',
+      events: [
+        { title: '데모데이 준비 및 점검', date: '팀별 개별 미팅', isDisabled: false },
+      ],
+    },
+    {
+      month: '11월',
+      events: [
+        { title: '데모데이', date: '추후 공지', isDisabled: false },
+      ],
+    },
+  ];
+
+  return (
+    <div className="bg-bg-dark min-h-screen text-white">
+      {/* 헤더 섹션 */}
+      <section className="py-16 px-4 sm:px-8 border-b border-gray-07">
+        <p className="detail-12-regular text-orange-04 mb-4">행사 일정</p>
+
+        <div className="flex items-end gap-4">
+          <h1 className="title-64-bold">Program</h1>
+
+          <div className="h-full flex items-end">
+            <p className="body-14-regular text-gray-05 leading-relaxed">
+              2024년 멋쟁이사자처럼 14기에서 진행할
+              <br />
+              1년 로드맵을 소개합니다
+            </p>
+          </div>
+        </div>
+      </section>
+
+      {/* 컨텐츠 섹션 */}
+      <section className="py-20 px-4 sm:px-8">
+        
+        {/* 1학기에만 description 전달 */}
+        <EventSeason 
+          season="1학기" 
+          monthsData={eventsSemester1} 
+          seasonColor="#FFFFFF"
+          description={
+            <p className="body-14-regular text-gray-05">
+              * 모든 일정은 학사 일정 및 상황에 따라 변경될 수 있습니다.
+            </p>
+          } 
+        />
+
+        {/* 나머지 계절은 description 없이 사용 */}
+        <EventSeason season="방학" monthsData={eventsSummer} seasonColor="#DC8563" />
+        <EventSeason season="2학기" monthsData={eventsSemester2} seasonColor="#FFFFFF" />
+      
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
## #️⃣관련 이슈
#2 [UI] 행사일정 페이지 구현

close: #이슈번호
2

## 📝작업 내용
행사일정 페이지 구현 + 색상 시스템 수정 + 디자인 시스템 수정

### 📸스크린샷 (선택)
<img width="1884" height="1086" alt="image" src="https://github.com/user-attachments/assets/1ca949a0-e505-4304-bb4a-ae00c5fce6f2" />

## 💬리뷰어에게 (선택)
레이아웃 적용되면 더 예쁘게 될 것 같고요.. 조금 더 수정할 사항이 있긴한데 디자인 시스템 놓쳤던 부분을 같이 하느라 pr 먼저 올립니다.
