### PR TITLE
Feature/#2 events schedule UI

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,15 +1,21 @@
-import { BrowserRouter as Router, Route, Routes } from "react-router-dom"
-import ColorTest from "./components/common/ColorTest"
+import { BrowserRouter as Router, Route, Routes } from "react-router-dom";
+import Layout from "./layout/Layout";
+import ColorTest from "./components/common/ColorTest";
 import Home from './pages/Home';
-import Events from "./pages/Events"
+import Events from "./pages/Events";
 
 function App() {
   return (
     <Router>
       <Routes>
-        <Route path="/color-test" element={<ColorTest />} />
+        {/* 1. 레이아웃이 필요한 페이지들 (그룹으로 묶음) */}
+        <Route element={<Layout />}>
+          <Route path="/color-test" element={<ColorTest />} />
+          <Route path="/events" element={<Events />} />
+        </Route>
+
+        {/* 2. 레이아웃이 필요 없는 페이지 (그룹 밖으로 뺌) */}
         <Route path="/" element={<Home />} />
-        <Route path="/events" element={<Events />} />
       </Routes>
     </Router>
   );

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,8 @@ import Layout from "./layout/Layout";
 import ColorTest from "./components/common/ColorTest";
 import Home from './pages/Home';
 import Events from "./pages/Events";
+import Archaive from "./pages/Archaive";
+import Recruiting from "./pages/Recruiting";
 
 function App() {
   return (
@@ -12,6 +14,8 @@ function App() {
         <Route element={<Layout />}>
           <Route path="/color-test" element={<ColorTest />} />
           <Route path="/events" element={<Events />} />
+          <Route path="/archaive" element={<Archaive />} />
+          <Route path="/recruiting" element={<Recruiting />} />
         </Route>
 
         {/* 2. 레이아웃이 필요 없는 페이지 (그룹 밖으로 뺌) */}

--- a/src/components/common/PageHeader.jsx
+++ b/src/components/common/PageHeader.jsx
@@ -4,12 +4,12 @@ const PageHeader = ({ title, subtitle, description }) => {
     <section className="py-16 w-full border-b border-gray-07 px-[150px]">
       
       {/* 소제목 (예: 행사 일정) */}
-      <p className="body-16-semibold text-orange-04 mb-4">
+      <p className="body-16-semibold text-orange-04">
         {subtitle}
       </p>
 
       {/* 대제목과 설명글을 가로로 배치하고 아래쪽 라인을 맞춤 */}
-      <div className="flex items-end gap-4">
+      <div className="flex items-end gap-6">
         
         {/* 대제목 (예: Program) */}
         <h1 className="title-120-bold">

--- a/src/components/common/PageHeader.jsx
+++ b/src/components/common/PageHeader.jsx
@@ -1,0 +1,30 @@
+const PageHeader = ({ title, subtitle, description }) => {
+  return (
+    // 상하 패딩(py-16)과 하단 테두리(border-b)만 유지했습니다.
+    <section className="py-16 w-full border-b border-gray-07 px-[150px]">
+      
+      {/* 소제목 (예: 행사 일정) */}
+      <p className="body-16-semibold text-orange-04 mb-4">
+        {subtitle}
+      </p>
+
+      {/* 대제목과 설명글을 가로로 배치하고 아래쪽 라인을 맞춤 */}
+      <div className="flex items-end gap-4">
+        
+        {/* 대제목 (예: Program) */}
+        <h1 className="title-120-bold">
+          {title}
+        </h1>
+
+        {/* 설명글 */}
+        <div className="h-full flex items-end pb-4"> {/* 폰트 베이스라인 미세 조정을 위해 pb 추가 */}
+          <p className="body-16-semibold text-gray-05 leading-relaxed whitespace-pre-wrap">
+            {description}
+          </p>
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default PageHeader;

--- a/src/components/events/EventCard.jsx
+++ b/src/components/events/EventCard.jsx
@@ -24,7 +24,7 @@ export default function EventCard({ title, date, isDisabled = false, colSpan = 1
       {/* 제목 부분 */}
       <div
         className={`
-          px-6 py-4 text-center flex items-center justify-center h-20 rounded-lg transition-all duration-200
+          px-6 py-4 text-center flex items-center justify-center h-15 rounded-lg transition-all duration-200
           ${
             isDisabled
               ? 'bg-gray-04 text-black opacity-60'
@@ -38,7 +38,7 @@ export default function EventCard({ title, date, isDisabled = false, colSpan = 1
       {/* 날짜 부분 */}
       <div
         className={`
-          px-6 py-4 text-center flex items-center justify-center h-20 rounded-lg transition-all duration-200
+          px-6 py-4 text-center flex items-center justify-center h-15 rounded-lg transition-all duration-200
           ${
             isDisabled
               ? 'text-gray-04 opacity-60'

--- a/src/index.css
+++ b/src/index.css
@@ -235,4 +235,3 @@
   .bg-orange-gradient {
     background: linear-gradient(135deg, #BA4E23 0%, #080300 100%);
   }
-}

--- a/src/layout/ButtonApply.jsx
+++ b/src/layout/ButtonApply.jsx
@@ -1,6 +1,6 @@
 import arrow from '../assets/icon/arrow.svg';
 
-const ButtonApply = ({ type, className }) => {
+const ButtonApply = ({ type, className, onClick }) => {
   const long =
     ' pl-[32px] pr-[24px] py-[8px] text-[24px] font-gray-01 whitespace-nowrap';
   const short = 'w-[95px] px-[16px] py-[8px] text-[18px] whitespace-nowrap';
@@ -10,6 +10,7 @@ const ButtonApply = ({ type, className }) => {
 
   return (
     <button
+      onClick={onClick}
       className={
         'button_layout button_text flex justify-center items-center ' +
         (type === 'long' ? long : short) +

--- a/src/layout/Layout.jsx
+++ b/src/layout/Layout.jsx
@@ -1,0 +1,51 @@
+import { Outlet, useLocation } from 'react-router-dom';
+import Navbar from './Navbar';
+import PageHeader from '../components/common/PageHeader';
+
+const Layout = () => {
+  const location = useLocation();
+
+  // 페이지별 헤더 내용 (URL 경로 : 내용)
+  const headerConfig = {
+    '/events': {
+      subtitle: '행사 일정',
+      title: 'Program',
+      description: '2024년 멋쟁이사자처럼 14기에서 진행할\n1년 로드맵을 소개합니다',
+    },
+
+    '/archaive': {
+      subtitle: '지난 활동',
+      title: 'Archaive',
+      description: '2025년 멋쟁이 사자처럼 13기에서 진행한\n프로젝트와 활동을 소개합니다.',
+    },
+
+    '/recruiting': {
+      subtitle: '모집 안내',
+      title: 'Recruiting',
+      description: '2026년 멋쟁이사자처럼을 함깨할 14기 멤버를 모집합니다.\n일정 및 소개를 반드시 읽고 지원폼을 제출해주세요.',
+    },
+  };
+
+  // 현재 주소에 맞는 정보 가져오기
+  const currentHeader = headerConfig[location.pathname];
+
+  return (
+    <div className="w-full min-h-screen bg-bg-dark">
+      <Navbar />
+      {currentHeader && (
+        <PageHeader 
+          subtitle={currentHeader.subtitle}
+          title={currentHeader.title}
+          description={currentHeader.description}
+        />
+      )}
+      
+      {/* 본문 영역: 헤더와 라인을 맞추기 위해 px-[120px] 적용 */}
+      <main className="w-full px-[120px] py-10">
+        <Outlet />
+      </main>
+    </div>
+  );
+};
+
+export default Layout;

--- a/src/layout/Navbar.jsx
+++ b/src/layout/Navbar.jsx
@@ -1,13 +1,18 @@
 import ButtonApply from './ButtonApply';
+import { useNavigate } from 'react-router-dom';
 
 const Navbar = () => {
+  const navigate = useNavigate();
+
   return (
     <>
       <div
         alt="navbar"
         className="w-full h-[58px] bg-bg-dark flex items-center justify-between px-[120px] my-[8px] py-[8px]"
       >
-        <div className="px-[32px] py-[16px] cursor-pointer navbar_title hover:text-gray-02">
+        <div 
+          onClick={() => navigate('/')}
+          className="px-[32px] py-[16px] cursor-pointer navbar_title hover:text-gray-02">
           LIKE LION HONGIK
         </div>
         <div
@@ -21,7 +26,9 @@ const Navbar = () => {
             <div className="px-[24px] py-[16px] cursor-pointer hover:bg-[radial-gradient(50%_50%_at_50%_50%,#BA4E23_0%,#080300_100%)]">
               지난 활동
             </div>
-            <div className="px-[24px] py-[16px] cursor-pointer hover:bg-[radial-gradient(50%_50%_at_50%_50%,#BA4E23_0%,#080300_100%)]">
+            <div 
+              onClick={() => navigate('/events')}
+              className="px-[24px] py-[16px] cursor-pointer hover:bg-[radial-gradient(50%_50%_at_50%_50%,#BA4E23_0%,#080300_100%)]">
               행사 일정
             </div>
             <div className="px-[24px] py-[16px] cursor-pointer hover:bg-[radial-gradient(50%_50%_at_50%_50%,#BA4E23_0%,#080300_100%)]">

--- a/src/layout/Navbar.jsx
+++ b/src/layout/Navbar.jsx
@@ -20,10 +20,14 @@ const Navbar = () => {
           className="flex justify-between items-center "
         >
           <div className="navbar_explanation justify-center items-center flex">
-            <div className="px-[24px] py-[16px] cursor-pointer hover:bg-[radial-gradient(50%_50%_at_50%_50%,#BA4E23_0%,#080300_100%)]">
+            <div 
+              onClick={() => navigate('/recruiting')}
+              className="px-[24px] py-[16px] cursor-pointer hover:bg-[radial-gradient(50%_50%_at_50%_50%,#BA4E23_0%,#080300_100%)]">
               모집 안내
             </div>
-            <div className="px-[24px] py-[16px] cursor-pointer hover:bg-[radial-gradient(50%_50%_at_50%_50%,#BA4E23_0%,#080300_100%)]">
+            <div 
+              onClick={() => navigate('/archaive')}
+              className="px-[24px] py-[16px] cursor-pointer hover:bg-[radial-gradient(50%_50%_at_50%_50%,#BA4E23_0%,#080300_100%)]">
               지난 활동
             </div>
             <div 

--- a/src/pages/Archaive.jsx
+++ b/src/pages/Archaive.jsx
@@ -1,0 +1,7 @@
+const Archaive = () => {
+    return (
+        <div>지난 활동 페이지 입니다.</div>
+    )
+};
+
+export default Archaive;

--- a/src/pages/Events.jsx
+++ b/src/pages/Events.jsx
@@ -1,4 +1,5 @@
 import EventSeason from '../components/events/EventSeason';
+import PageHeader from "../components/common/PageHeader";
 
 export default function Events() {
   // 1학기
@@ -77,25 +78,8 @@ export default function Events() {
 
   return (
     <div className="bg-bg-dark min-h-screen text-white">
-      {/* 헤더 섹션 */}
-      <section className="py-16 px-4 sm:px-8 border-b border-gray-07">
-        <p className="detail-12-regular text-orange-04 mb-4">행사 일정</p>
-
-        <div className="flex items-end gap-4">
-          <h1 className="title-64-bold">Program</h1>
-
-          <div className="h-full flex items-end">
-            <p className="body-14-regular text-gray-05 leading-relaxed">
-              2024년 멋쟁이사자처럼 14기에서 진행할
-              <br />
-              1년 로드맵을 소개합니다
-            </p>
-          </div>
-        </div>
-      </section>
-
       {/* 컨텐츠 섹션 */}
-      <section className="py-20 px-4 sm:px-8">
+      <section className="py-20">
         
         {/* 1학기에만 description 전달 */}
         <EventSeason 

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,6 +1,6 @@
 import lion from '../assets/home/logo-lion.svg';
 import hongik from '../assets/home/logo-hongik.svg';
-import Navbar from '../layout/NavBar';
+import Navbar from '../layout/Navbar';
 import ButtonApply from '../layout/ButtonApply';
 
 const Home = () => {

--- a/src/pages/Recruiting.jsx
+++ b/src/pages/Recruiting.jsx
@@ -1,0 +1,7 @@
+const Recruiting = () => {
+    return (
+        <div>모집 안내 페이지 입니다.</div>
+    )
+};
+
+export default Recruiting;


### PR DESCRIPTION
## #️⃣관련 이슈
2

close: #이슈번호

## 📝작업 내용
네브바에서 각 페이지 눌렀을때 넘어가게 했습니다. (F&Q 제외, 헤더섹션이 다른 페이지랑 달라서..)
행사 일정 페이지 ui 조금 수정했습니다.

### 📸스크린샷 (선택)
<img width="1901" height="766" alt="image" src="https://github.com/user-attachments/assets/6359a7c9-a8e1-4cdf-b8a1-2e2672dd96ff" />
<img width="1895" height="835" alt="image" src="https://github.com/user-attachments/assets/b1a68225-6874-404a-ad08-56e712546c91" />
<img width="1886" height="960" alt="image" src="https://github.com/user-attachments/assets/013b6ce9-7ca8-4968-ab52-45661147ceb0" />


## 💬리뷰어에게 (선택)
페이지 작업할때 좌우 여백 조금 신경 써서 맞춰주시면 감사하겠습니다.
