### PR TITLE
#2 [UI] 페이지 헤더 반응형 / 행사 일정 페이지 반응형 구현

### DIFF
--- a/src/components/common/PageHeader.jsx
+++ b/src/components/common/PageHeader.jsx
@@ -1,19 +1,20 @@
 const PageHeader = ({ title, subtitle, description }) => {
   return (
-    // 상하 패딩(py-16)과 하단 테두리(border-b)만 유지했습니다.
     <section className="py-16 w-full border-b border-gray-07">
-      {/* 소제목 (예: 행사 일정) */}
-      <p className="body-16-semibold text-orange-04">{subtitle}</p>
+      {/* 소제목 */}
+      <p className="body-16-semibold text-orange-04 mb-2 lg:mb-0">{subtitle}</p>
 
-      {/* 대제목과 설명글을 가로로 배치하고 아래쪽 라인을 맞춤 */}
-      <div className="flex items-end gap-6">
-        {/* 대제목 (예: Program) */}
-        <h1 className="title-120-bold">{title}</h1>
+      {/* lg:items-end : 1024px 이상에서 하단 정렬 */}
+      <div className="flex flex-col lg:flex-row lg:items-end gap-4 lg:gap-6">
+        
+        {/* 대제목 */}
+        <h1 className="font-bold leading-none text-[48px] md:text-[80px] lg:text-[100px] xl:text-[120px] break-words lg:shrink-0">
+          {title}
+        </h1>
 
-        {/* 설명글 */}
-        <div className="h-full flex items-end pb-4">
-          {/* 폰트 베이스라인 미세 조정을 위해 pb 추가 */}
-          <p className="body-16-semibold text-gray-05 leading-relaxed whitespace-pre-wrap">
+        {/* 설명글 영역 */}
+        <div className="w-full lg:pb-2">
+          <p className="body-12-semibold md:body-16-semibold text-gray-05 leading-relaxed whitespace-pre-wrap">
             {description}
           </p>
         </div>

--- a/src/components/events/EventCard.jsx
+++ b/src/components/events/EventCard.jsx
@@ -6,14 +6,11 @@ export default function EventCard({ title, date, isDisabled = false, colSpan = 1
   const getColSpanClass = (span) => {
     switch (span) {
       case 4:
-        // 모바일(1) -> 태블릿(2) -> 작은PC(3) -> 큰PC(4) 순으로 그리드가 커지므로
-        // 각 브레이크포인트에서 최대 너비를 차지하도록 설정
-        return 'col-span-1 sm:col-span-2 md:col-span-3 lg:col-span-4';
+        return 'col-span-1 lg:col-span-4';
       case 3:
-        // 4열 그리드일 때 3칸 차지
-        return 'lg:col-span-3';
+        return 'col-span-1 lg:col-span-3';
       case 2:
-        return 'sm:col-span-2';
+        return 'col-span-1 lg:col-span-2';
       default:
         return 'col-span-1';
     }
@@ -27,12 +24,12 @@ export default function EventCard({ title, date, isDisabled = false, colSpan = 1
           px-6 py-4 text-center flex items-center justify-center h-15 rounded-lg transition-all duration-200
           ${
             isDisabled
-              ? 'bg-gray-04 text-black opacity-60'
+              ? 'bg-gray-04 text-bg-dark opacity-60'
               : 'bg-bright-orange-02 text-bg-dark hover:shadow-lg'
           }
         `}
       >
-        <div className="body-18-bold">{title}</div>
+        <div className="body-16-semibold lg:body-18-semibold">{title}</div>
       </div>
 
       {/* 날짜 부분 */}
@@ -49,7 +46,11 @@ export default function EventCard({ title, date, isDisabled = false, colSpan = 1
           }
         `}
       >
-        <div className={hasDateNumber ? "body-18-bold" : "body-18-regular"}>
+        <div className={
+          hasDateNumber 
+            ? "body-16-semibold lg:body-18-semibold" 
+            : "body-16-regular lg:body-18-regular"
+        }>
           {date}
         </div>
       </div>

--- a/src/components/events/EventSeason.jsx
+++ b/src/components/events/EventSeason.jsx
@@ -4,10 +4,12 @@ export default function EventSeason({ season, monthsData, seasonColor, descripti
   const filteredMonths = monthsData.filter(monthData => monthData.events.length > 0);
 
   return (
-    <div className="flex gap-6 mb-16">
+    // 1. gap-3 lg:gap-6 : 모바일에서 간격을 좁혀서 오른쪽 공간 확보
+    <div className="flex gap-3 lg:gap-6 mb-16">
       
       {/* 1. 왼쪽: 계절 제목 */}
-      <div className="flex-shrink-0 text-right pt-1">
+      {/* w-12 lg:w-16 : 모바일에서 제목 영역 너비를 조금 더 줄임 */}
+      <div className="flex-shrink-0 text-right pt-1 w-12 lg:w-16 sm:w-auto">
         <h2 
           className="title-24-semibold break-keep"
           style={{ color: seasonColor }}
@@ -18,12 +20,15 @@ export default function EventSeason({ season, monthsData, seasonColor, descripti
 
       {/* 2. 중앙: 세로 줄 */}
       <div className="flex flex-col items-center relative">
+        {/* w-0.5 lg:w-1 : 모바일에서는 선 두께를 얇게(0.5) 처리 */}
         <div 
-          className="w-1 flex-1 -mt-2"
+          className="w-0.5 lg:w-1 flex-1 -mt-2"
           style={{ backgroundColor: seasonColor }}
         ></div>
+        
+        {/* w-2 h-2 lg:w-4 lg:h-4 : 모바일에서는 원 크기를 작게 처리 */}
         <div 
-          className="w-4 h-4 rounded-full flex-shrink-0 z-10"
+          className="w-2 h-2 lg:w-4 lg:h-4 rounded-full flex-shrink-0 z-10"
           style={{ backgroundColor: seasonColor }}
         ></div>
       </div>
@@ -36,11 +41,14 @@ export default function EventSeason({ season, monthsData, seasonColor, descripti
           </div>
         )}
 
-        <div className="space-y-12">
+        {/* 달(Month) 목록 컨테이너 */}
+        <div className="grid grid-cols-2 gap-x-4 gap-y-12 lg:gap-x-6 lg:block lg:space-y-12">
           {filteredMonths.map((monthData) => (
-            <div key={monthData.month}>
+            <div key={monthData.month} className="col-span-1">
               <h3 className="title-28-semibold text-white mb-4">{monthData.month}</h3>
-              <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+              
+              {/* 이벤트 카드 리스트 그리드 */}
+              <div className="grid grid-cols-1 gap-4 lg:grid-cols-4">
                 {monthData.events.map((event, index) => (
                   <EventCard
                     key={index}


### PR DESCRIPTION
## #️⃣관련 이슈
2

close: #이슈번호

## 📝작업 내용
페이지 헤더 반응형
행사일정 페이지 반응형

### 📸스크린샷 (선택)
데스크탑
<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/7fa16f9f-5aee-4b65-a230-345820f4a14e" />

패드
<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/7f06bbc3-9145-46ae-99ec-d26058a16668" />

폰
<img width="1920" height="1140" alt="image" src="https://github.com/user-attachments/assets/28ecd575-6e60-4ec2-b461-2b9ca6808150" />

## 💬리뷰어에게 (선택)
